### PR TITLE
UX  improvement, replace select element by datalist

### DIFF
--- a/calculations.js
+++ b/calculations.js
@@ -54,7 +54,8 @@ function selectDragon() {
     const firstTrait = document.querySelector("#trait1");
     const secondTrait = document.querySelector("#trait2");
     const dragonName = document.querySelector("#dragon-selector").value;
-    const dragonIndex = dragonList.findIndex((dragons) => { return dragons.name[0] === dragonName; });
+    const dragonIndex = dragonList.findIndex((dragons) => { return dragons.name[1] === dragonName; });
+    if(dragonIndex === -1) {document.querySelector("#start-trait-selector").setAttribute("disabled", ""); return;}
 
     // Enable trait selector
     document.querySelector("#start-trait-selector").removeAttribute("disabled");
@@ -74,8 +75,7 @@ function selectDragon() {
 function selectStartTrait(e) {
     const traitSelected = e.target.value;
     const dragonName = document.querySelector("#dragon-selector").value;
-    const dragonIndex = dragonList.findIndex((dragons) => { return dragons.name[0] === dragonName; });
-
+    const dragonIndex = dragonList.findIndex((dragons) => { return dragons.name[1] === dragonName; });
     // Fill in base stats
     STAT_LISTS.start.forEach((stat, i) => document.querySelector(stat).value = dragonList[dragonIndex][traitSelected][i]);
 

--- a/dvccalculator.css
+++ b/dvccalculator.css
@@ -188,6 +188,10 @@ span.three {
         min-width: 700px;
     }
 
+    #dragon-selector {
+        width: 140px;
+    }
+
     #start-trait-selector {
         width: 100px;
     }

--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
         document.addEventListener("DOMContentLoaded", function () {
             for (let i = 0; i < dragonList.length; i++) {
                 const newOption = document.createElement("option");
-                newOption.setAttribute("value", dragonList[i].name[0]);
-                newOption.textContent = dragonList[i].name[1];
-                document.querySelector("#dragon-selector").append(newOption);
+                newOption.setAttribute("data-value", dragonList[i].name[0]);
+                newOption.setAttribute("value", dragonList[i].name[1]);
+                document.querySelector("#dragon-list").append(newOption);
             }
 
             for (let i = 0; i < normalTraits.length; i++) {
@@ -168,9 +168,13 @@
             <div id="controls">
                 <div class="sel1">
                     <h3>選擇龍種:</h3>
-                    <select name="dragon-selector" id="dragon-selector" onchange="selectDragon()">
-                        <option selected disabled>龍</option>
-                    </select>
+                    <input list="dragon-list" id="dragon-selector" name="dragon-selector" placeholder="龍" onchange="selectDragon()">
+                    <datalist id="dragon-list" name="dragon-list">
+                        <!-- fallback -->
+                        <!-- <select name="dragon-selector" id="dragon-selector" onchange="selectDragon()">
+                        </select> -->
+                    </datalist> 
+
                     <select name="trait-selector" id="start-trait-selector" onchange="selectStartTrait(event)" disabled>
                         <option selected disabled>初始個性</option>
                         <option value="" id="trait1">-</option>


### PR DESCRIPTION
您好，
使用的時候覺得選項太多很難選，想把選擇器改成可搜尋的
所以用 html5 的 `<datalist>` 取代 `<select>`

`<datalist>` Reference:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
https://dowyuu.github.io/program/2020/05/27/Input-Datalist/

### Demo
![ezgif-3-15ba5a80f2](https://github.com/YCCCCode/yccccode.github.io/assets/6376572/03d4277d-4da2-4195-84f7-8c683b7260f9)

我只有在電腦上錄影，手機上面的呈現方式會不太一樣，可以在手機上玩看看，應該不會有什麼問題（？

瀏覽器支援度的部分可以看[這裡](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist#browser_compatibility)，感覺不會有玩家使用這些老舊的瀏覽器，可以放心使用
